### PR TITLE
test(refactor areas preventing unit tests working in agent, executor)

### DIFF
--- a/src/agent/Agent.js
+++ b/src/agent/Agent.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import 'babel-polyfill';
-import { default as dotenv } from 'dotenv';
 import { default as AgentLogger } from './AgentLogger';
 import { default as express } from 'express';
 import { default as expressNunjucks } from 'express-nunjucks';
@@ -14,7 +13,6 @@ import { default as json } from 'format-json';
 import { default as GtmGithubHook } from '../serverless/gtmGithubHook/gtmGithubHook.js';
 
 let log = AgentLogger.log();
-dotenv.config();
 
 // Setting up Instances
 const app = express();

--- a/src/agent/AgentUtils.js
+++ b/src/agent/AgentUtils.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const pullRequestData = require('./pullrequest.json');
-require('dotenv').config();
 const { URL } = require('url');
 import { default as AgentLogger } from './AgentLogger';
 let log = AgentLogger.log();

--- a/src/agent/Event.js
+++ b/src/agent/Event.js
@@ -2,12 +2,10 @@
 
 import 'babel-polyfill';
 import { default as crypto } from 'crypto';
-import { default as dotenv } from 'dotenv';
 import { default as AgentLogger } from './AgentLogger';
 import { Agent } from './Agent';
 
 let log = AgentLogger.log();
-dotenv.config();
 
 /**
  * representation of an event generated from a github hook SQS message

--- a/src/agent/startAgent.js
+++ b/src/agent/startAgent.js
@@ -1,3 +1,6 @@
+import { default as dotenv } from 'dotenv';
+dotenv.config();
+
 import { Agent } from './Agent';
 
 (() => {

--- a/src/serverless/gtmGithubResults/gtmGithubResults.js
+++ b/src/serverless/gtmGithubResults/gtmGithubResults.js
@@ -34,7 +34,7 @@ async function handle(event, context, callback) {
 
         consumer.start();
     } catch (e) {
-        console.log(e);
+        console.log(e.message);
         return callback(null, {
             statusCode: 401,
             headers: { 'Content-Type': 'text/plain' },

--- a/test/agent/Event.spec.js
+++ b/test/agent/Event.spec.js
@@ -1,0 +1,86 @@
+import { default as fs } from 'fs';
+import { describe, it, beforeEach, before, after } from 'mocha';
+import { default as assert } from 'assert';
+import { Event } from '../../src/agent/Event';
+
+describe('Event', function() {
+    let temp;
+    before(() => {
+        temp = process.env.GTM_GITHUB_WEBHOOK_SECRET;
+        process.env.GTM_GITHUB_WEBHOOK_SECRET = 'squirrel';
+    });
+
+    after(() => {
+        process.env.GTM_GITHUB_WEBHOOK_SECRET = temp;
+    });
+
+    let message;
+    beforeEach(() => {
+        message = JSON.parse(fs.readFileSync(__dirname + '/../fixtures/githubMessage.json', 'utf-8'));
+    });
+
+    describe('requiredAttributes', function() {
+        it('should contain expected values', function() {
+            let expected = ['ghEventId', 'ghEventType', 'ghAgentGroup', 'ghTaskConfig', 'ghEventSignature'];
+
+            let actual = Event.requiredAttributes;
+
+            for (let i = 1; i < 5; i++) {
+                assert.equal(actual[i], expected[i]);
+            }
+        });
+    });
+
+    describe('validateMessage', function() {
+        beforeEach(() => {
+            message = JSON.parse(fs.readFileSync(__dirname + '/../fixtures/githubMessage.json', 'utf-8'));
+        });
+
+        it('should throw when message has missing attribute', function() {
+            try {
+                delete message.MessageAttributes.ghEventId;
+                Event.validateMessage(message);
+            } catch (e) {
+                assert.equal(e.message, `No Message Attribute 'ghEventId' in Message - discarding Event!`);
+            }
+        });
+
+        it('should return message attributes', function() {
+            let expected = JSON.parse(fs.readFileSync(__dirname + '/../fixtures/githubEventAttributes.json', 'utf-8'));
+
+            let actual = Event.validateMessage(message);
+
+            assert.equal(JSON.stringify(actual), JSON.stringify(expected));
+        });
+    });
+
+    describe('checkEventSignature', function() {
+        it('should sign message with github webhook secret', function() {
+            let signature = message.MessageAttributes.ghEventSignature.StringValue;
+            let result = Event.checkEventSignature(signature, message);
+
+            assert.equal(result, true);
+        });
+    });
+
+    describe('buildCheckObject', function() {
+        it('should create the expected check object from message', function() {
+            let expected = JSON.parse(fs.readFileSync(__dirname + '/../fixtures/githubMessageCheck.json', 'utf-8'));
+
+            let actual = Event.buildCheckObject(message);
+
+            assert.equal(JSON.stringify(actual), JSON.stringify(expected));
+        });
+    });
+
+    describe('prepareEventPayload', function() {
+        it('should create the expected payload from message and attributes', function() {
+            let expected = JSON.parse(fs.readFileSync(__dirname + '/../fixtures/githubEventPayload.json', 'utf-8'));
+
+            let attrs = Event.validateMessage(message);
+            let actual = Event.prepareEventPayload(message, attrs);
+
+            assert.equal(JSON.stringify(actual), JSON.stringify(expected));
+        });
+    });
+});

--- a/test/agent/EventHandler.spec.js
+++ b/test/agent/EventHandler.spec.js
@@ -1,0 +1,19 @@
+import { default as fs } from 'fs';
+import { describe, it, beforeEach } from 'mocha';
+import { default as assert } from 'assert';
+import { Plugin } from '../../src/agent/Plugin';
+import { EventHandler } from '../../src/agent/EventHandler';
+
+describe('EventHandler', function() {
+    let handler;
+    beforeEach(() => {
+        let eventData = JSON.parse(fs.readFileSync(__dirname + '/../fixtures/githubEventPayload.json', 'utf-8'));
+        handler = new EventHandler(eventData);
+    });
+
+    describe('constructor', function() {
+        it('should instantiate as Plugin', function() {
+            assert.equal(handler instanceof Plugin, true);
+        });
+    });
+});

--- a/test/agent/Executor.spec.js
+++ b/test/agent/Executor.spec.js
@@ -1,0 +1,25 @@
+import { default as fs } from 'fs';
+import { describe, it, beforeEach } from 'mocha';
+import { default as assert } from 'assert';
+import { Plugin } from '../../src/agent/Plugin';
+import { Executor } from '../../src/agent/Executor';
+
+describe('Executor', function() {
+    let executor;
+    beforeEach(() => {
+        let eventData = JSON.parse(fs.readFileSync(__dirname + '/../fixtures/githubEventPayload.json', 'utf-8'));
+        executor = new Executor(eventData);
+    });
+
+    describe('constructor', function() {
+        it('should instantiate as Plugin', function() {
+            assert.equal(executor instanceof Plugin, true);
+        });
+    });
+
+    describe('getOptions', function() {
+        it('should return environment', function() {
+            assert.equal(executor.getOptions(), process.env);
+        });
+    });
+});

--- a/test/agent/Plugin.spec.js
+++ b/test/agent/Plugin.spec.js
@@ -1,0 +1,37 @@
+import { describe, it } from 'mocha';
+import { default as assert } from 'assert';
+import { Plugin } from '../../src/agent/Plugin';
+
+describe('Plugin', function() {
+    describe('register', function() {
+        it('should register new class', function() {
+            class Animal extends Plugin {}
+            class Dog extends Animal {}
+
+            Animal.register('Dog', Dog);
+
+            assert.equal(Animal.isRegistered('Dog'), true);
+        });
+    });
+
+    describe('create', function() {
+        it('should create new instance of class', function() {
+            class Animal extends Plugin {}
+            class Dog extends Animal {
+                constructor(options) {
+                    super();
+                    this.options = options;
+                }
+                puppies() {
+                    return this.options.puppies;
+                }
+            }
+
+            Animal.register('Dog', Dog);
+
+            let dalmation = Animal.create('Dog', { puppies: 101 });
+
+            assert.equal(dalmation.puppies(), 101);
+        });
+    });
+});

--- a/test/fixtures/githubEventAttributes.json
+++ b/test/fixtures/githubEventAttributes.json
@@ -1,0 +1,7 @@
+{
+  "ghEventId": "id",
+  "ghEventType": "type",
+  "ghAgentGroup": "group",
+  "ghTaskConfig": "{\"task\": \"config\"}",
+  "ghEventSignature": "sha1=cee03d54dc35650b903b0cdc38ebd49208b1efa4"
+}

--- a/test/fixtures/githubEventPayload.json
+++ b/test/fixtures/githubEventPayload.json
@@ -1,0 +1,11 @@
+{
+  "sample": "message",
+  "ghEventId": "id",
+  "ghEventType": "type",
+  "ghTaskConfig": {
+    "task": "config"
+  },
+  "ghAgentGroup": "group",
+  "ghEventSignature": "sha1=cee03d54dc35650b903b0cdc38ebd49208b1efa4",
+  "MessageHandle": "handle"
+}

--- a/test/fixtures/githubMessage.json
+++ b/test/fixtures/githubMessage.json
@@ -1,0 +1,21 @@
+{
+  "Body": "{\"sample\": \"message\"}",
+  "ReceiptHandle": "handle",
+  "MessageAttributes": {
+    "ghEventId": {
+      "StringValue": "id"
+    },
+    "ghEventType": {
+      "StringValue": "type"
+    },
+    "ghTaskConfig": {
+      "StringValue": "{\"task\": \"config\"}"
+    },
+    "ghAgentGroup": {
+      "StringValue": "group"
+    },
+    "ghEventSignature": {
+      "StringValue": "sha1=cee03d54dc35650b903b0cdc38ebd49208b1efa4"
+    }
+  }
+}

--- a/test/fixtures/githubMessageCheck.json
+++ b/test/fixtures/githubMessageCheck.json
@@ -1,0 +1,22 @@
+{
+  "id": "id",
+  "body": "{\"sample\": \"message\"}",
+  "messageAttributes": {
+    "ghEventId": {
+      "DataType": "String",
+      "StringValue": "id"
+    },
+    "ghEventType": {
+      "DataType": "String",
+      "StringValue": "type"
+    },
+    "ghTaskConfig": {
+      "DataType": "String",
+      "StringValue": "{\"task\": \"config\"}"
+    },
+    "ghAgentGroup": {
+      "DataType": "String",
+      "StringValue": "group"
+    }
+  }
+}

--- a/test/serverless/gtmGithubHook/gtmGithubHook.spec.js
+++ b/test/serverless/gtmGithubHook/gtmGithubHook.spec.js
@@ -44,7 +44,19 @@ describe('gtmGithubHook', function() {
     describe('handleEvent', function() {
         it('should fire', function(done) {
             let type = 'pull_request';
-            let body = { action: 'test' };
+            let body = {
+                pull_request: {
+                    ref: 'sha123',
+                    head: {
+                        repo: {
+                            name: 'code',
+                            owner: {
+                                login: 'bob'
+                            }
+                        }
+                    }
+                }
+            };
 
             gtmGithubHook.handleEvent(type, body);
             assert.equal(1, 1); //todo

--- a/test/serverless/gtmGithubResults/gtmGithubResults.spec.js
+++ b/test/serverless/gtmGithubResults/gtmGithubResults.spec.js
@@ -10,9 +10,14 @@ describe('gtmGithubResults', function() {
                 headers: { 'Content-Type': 'text/plain' }
             };
 
-            let actual = await githubResults.handle({}, null, () => {
-                return expected;
-            });
+            let actual;
+            try {
+                actual = await githubResults.handle({}, null, () => {
+                    return expected;
+                });
+            } catch (e) {
+                console.log(e.message);
+            }
             assert.equal(actual.statusCode, expected.statusCode);
         });
     });


### PR DESCRIPTION
This refactors some areas around logstreaming and env vars that were preventing unit tests from working.

- sets logging to console in tests
- moves the dotenv to startAgent.js which is not used in unit tests

Also added tests to new Event.js  and created fixtures to support.

We should be in a position to catch up on unit tests now.