### PR TITLE
Implement Proxy Support in Bunyan Config Object

### DIFF
--- a/src/agent/Agent.js
+++ b/src/agent/Agent.js
@@ -104,7 +104,7 @@ export class Agent {
             };
 
             let virtualLambdaEvent = {
-                body: JSON.stringify(req.body),
+                body: req.body,
                 headers: req.headers,
                 httpMethod: req.method
             };

--- a/src/agent/AgentLogger.js
+++ b/src/agent/AgentLogger.js
@@ -3,6 +3,7 @@ import { default as bformat } from 'bunyan-format';
 import { default as createCWStream } from 'bunyan-cloudwatch';
 import { default as UUID } from 'uuid/v4';
 import { default as ExpressSSE } from 'express-sse';
+import { default as proxy } from 'proxy-agent';
 
 let SSE = [];
 let AGENT_ID = UUID();
@@ -21,12 +22,26 @@ let janitorInterval;
 function create(agentId) {
     if (!agentId) console.warn('agentId is not set.');
 
+    let CWLogOptions = {
+        region: process.env.GTM_AWS_REGION
+    }
+
+    if (process.env.AWS_PROXY) {
+        CWLogOptions = {
+            region: process.env.GTM_AWS_REGION,
+            accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+            sessionToken: process.env.AWS_SECURITY_TOKEN,
+            httpOptions: {
+                agent: proxy(process.env.AWS_PROXY)
+            }
+        }
+    }
+
     let stream = createCWStream({
         logGroupName: process.env.GTM_AGENT_CLOUDWATCH_LOGS_GROUP || 'gtmAgent',
         logStreamName: 'AGENT_ID=' + agentId,
-        cloudWatchLogsOptions: {
-            region: process.env.GTM_AWS_REGION
-        }
+        cloudWatchLogsOptions: CWLogOptions
     });
 
     janitorInterval = setInterval(streamJanitor, 60000);

--- a/src/agent/AgentLogger.js
+++ b/src/agent/AgentLogger.js
@@ -24,8 +24,10 @@ function create(agentId) {
 
     let CWLogOptions = {
         region: process.env.GTM_AWS_REGION
-    }
+    };
 
+    // If we're running behind a proxy, assume we're also using IAM Roles for auth
+    // TODO: AWS_PROXY should become IAM_ENABLED and defer proxy values to env
     if (process.env.AWS_PROXY) {
         CWLogOptions = {
             region: process.env.GTM_AWS_REGION,
@@ -35,7 +37,7 @@ function create(agentId) {
             httpOptions: {
                 agent: proxy(process.env.AWS_PROXY)
             }
-        }
+        };
     }
 
     let stream = createCWStream({


### PR DESCRIPTION
@wyvern8 @David-Jonathan I've added a change into AgentLogger.js to detect the AWS_PROXY env var and configure the CW logs instance appropriately. This is similar to the detection performed in the AgentUtils.js file.

Let me know what you guys think, the implementation looks like it could be sleeker, potentially merging hashes instead of overwriting the whole thing and duplicating the region key? If anyone wants to refactor please do :) 