### PR TITLE
Update Publish Hook to allow for Proxy

### DIFF
--- a/src/serverless/gtmGithubResults/gtmGithubResults.js
+++ b/src/serverless/gtmGithubResults/gtmGithubResults.js
@@ -3,6 +3,7 @@
 let json = require('format-json');
 let consumer = require('sqs-consumer');
 let githubUtils = require('../gtmGithubUtils.js');
+let proxy = require('proxy-agent');
 
 async function handle(event, context, callback) {
     /* eslint-disable */
@@ -44,11 +45,21 @@ async function handle(event, context, callback) {
 }
 
 async function getQueue() {
-    return await consumer.create({
+    
+    let awsOptions = {
         queueUrl: process.env.SQS_RESULTS_QUEUE_URL,
         waitTimeSeconds: 10,
         handleMessage: githubUtils.handleEventTaskResult
-    });
+    };
+    
+    if (process.env.AWS_PROXY) {
+        awsOptions.httpOptions = {
+            agent: proxy(process.env.AWS_PROXY)
+        };
+    }
+
+    return await consumer.create(awsOptions);
+    
 }
 
 module.exports = {


### PR DESCRIPTION
@wyvern8 @David-Jonathan Added proxy support to Lambda function. This might require a change in the serverless deploy package.json to add the dependency on proxy-agent...