### PR TITLE
Feature/jenkins build params

### DIFF
--- a/src/executors/ExecutorJenkins.js
+++ b/src/executors/ExecutorJenkins.js
@@ -98,24 +98,25 @@ export class ExecutorJenkins extends Executor {
         let jobName = task.options.jobName || null;
         let buildParams = task.options.parameters || null;
 
-        if (jobName == null || buildParams == null) {
+        let configuration = {};
+
+        if (jobName == null) {
             await AgentUtils.timeout(4000);
             task.results = {
                 passed: false,
                 url: this.options.GTM_JENKINS_URL,
-                message: `Required Parameters not Specified for ${jobName}`
+                message: `Required Parameter 'Job Name' not Specified`
             };
             return Promise.reject(task);
+        } else {
+            configuration.name = jobName;
         }
 
-        log.debug(buildParams);
+        if (buildParams != null) configuration.parameters = buildParams;
 
         log.info('Starting Jenkins Job: ' + jobName);
         // TODO: Check if Job Exists
-        let queueNumber = await this.jenkins.job.build({
-            name: jobName,
-            parameters: buildParams
-        });
+        let queueNumber = await this.jenkins.job.build(configuration);
         let buildNumber = await this.buildNumberfromQueue(queueNumber);
         let buildExists = await this.waitForBuildToExist(jobName, buildNumber);
         console.debug(buildExists);

--- a/test/executors/ExecutorJenkins.spec.js
+++ b/test/executors/ExecutorJenkins.spec.js
@@ -40,20 +40,6 @@ describe('ExecutorJenkins', function() {
             stubCall.restore();
         });
 
-        it('should return an object for misconfigured builds', async () => {
-            let sampleTask = {};
-            sampleTask.executor = 'Jenkins';
-            sampleTask.options = {
-                jobName: 'Test Job'
-            };
-            try {
-                let result = await executorJenkins.executeTask(sampleTask);
-                assert.equal(result.results.message, 'Required Parameters not Specified for Test Job');
-            } catch (result) {
-                assert.equal(result.results.message, 'Required Parameters not Specified for Test Job');
-            }
-        });
-
         it('executeTask to return result object', async () => {
             eventData = JSON.parse(
                 fs.readFileSync(__dirname + '/../fixtures/executorJenkinsTaskPayload.json', 'utf-8')


### PR DESCRIPTION
@wyvern8 @David-Jonathan  I've added a change to allow Jenkins jobs to run without parameters, as this is not handled in a 'nice' way by the underlying implementation. The change composes a configuration object allowing for the lack of a 'parameters' field, which if specified and 'null' causes the Jenkins library to fail, so in this case is simply not specified if that is the case.