### PR TITLE
feat(ExecutorTeamCity): Implement Branch Name Parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -474,20 +474,6 @@
       "dev": true,
       "optional": true
     },
-    "CBuffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/CBuffer/-/CBuffer-2.0.0.tgz",
-      "integrity": "sha1-+VbPZYiKiYjGn74slPlwA8m3Hho="
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "a-sync-waterfall": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
@@ -2496,6 +2482,11 @@
         "url-to-options": "1.0.1"
       }
     },
+    "CBuffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/CBuffer/-/CBuffer-2.0.0.tgz",
+      "integrity": "sha1-+VbPZYiKiYjGn74slPlwA8m3Hho="
+    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -3143,8 +3134,8 @@
       "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.2",
         "lodash": "4.17.5",
         "meow": "4.0.0",
         "split2": "2.2.0",
@@ -3857,8 +3848,8 @@
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.5.tgz",
       "integrity": "sha512-i3J4TYW9iNp+nWzkgGvj9UwSmT6ZUFg2OsjRlUraHCaDCv8z6f0fN3q4ur0Qq27/1GPYXSjShGaE7fDznIJKUg==",
       "requires": {
-        "JSONStream": "1.3.2",
         "debug": "3.1.0",
+        "JSONStream": "1.3.2",
         "readable-stream": "1.0.34",
         "split-ca": "1.0.1"
       },
@@ -4356,6 +4347,15 @@
             "signal-exit": "3.0.2"
           }
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4364,15 +4364,6 @@
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -5685,6 +5676,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5692,13 +5690,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7339,6 +7330,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsontoxml": {
       "version": "0.1.1",
@@ -12982,6 +12982,11 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -12991,11 +12996,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/src/executors/ExecutorTeamCity.js
+++ b/src/executors/ExecutorTeamCity.js
@@ -45,8 +45,14 @@ export class ExecutorTeamCity extends Executor {
     createTeamCityBuildNode(task, jobName) {
         let xml;
         let xmlNode = {
-            build: [{ name: 'buildType', attrs: { id: jobName } }, { name: 'properties', children: [] }]
+            name: 'build',
+            attrs: {},
+            children: [{ name: 'buildType', attrs: { id: jobName } }, { name: 'properties', children: [] }]
         };
+
+        if (task.options.hasOwnProperty('branchName')) {
+            xmlNode.attrs.branchName = task.options.branchName;
+        }
 
         for (var buildProperty in task.options.parameters) {
             let property = {
@@ -56,10 +62,10 @@ export class ExecutorTeamCity extends Executor {
                     value: task.options.parameters[buildProperty]
                 }
             };
-            xmlNode.build[1].children.push(property);
+            xmlNode.children[1].children.push(property);
         }
 
-        xml = xmlBuilder(xmlNode);
+        xml = xmlBuilder([xmlNode]);
         return xml;
     }
 


### PR DESCRIPTION
Updated TeamCity Executor to allow for a 'branchName' attribute in the options dictionary, specifying which branch of a project to build. This is useful in cases where you want to build a dependency or downstream build on a different branch than the one that triggered the event.

Example:

```
{
    "executor": "TeamCity",
    "context": "TeamCity Build",
    "options": {
        "jobName": "my_custom_teamcity_application",
        "branchName": "pull/51"
    }
}
```